### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ With Zato 2.0 or earlier, follow steps below:
 
 * Deploy <a href="https://github.com/zatosource/zato-labs/blob/main/ide-deploy/ide_deploy.py">this service</a> to a Zato cluster
 
-* Mount the newly deployed service on <a href="https://zato.io/docs/web-admin/channels/plain-http.html">an HTTP channel</a> with a URL path of /ide-upload
+* Mount the newly deployed service on <a href="https://zato.io/docs/web-admin/channels/plain-http.html">an HTTP channel</a> with a URL path of /ide-deploy
 
 * Continue to Setup section below
 


### PR DESCRIPTION
VS Code description misleads with provided address, when extension is hardcoded to look for an /ide-deploy URI